### PR TITLE
Use editor.tabSize config for JSON spacing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outFiles": ["out/src"],
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outFiles": ["out/test"],
 			"preLaunchTask": "npm"
 		}
 	]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,8 @@ import {
   Range,
   TextEditorDecorationType,
   window,
-  commands
+  commands,
+  workspace
 } from 'vscode';
 
 import * as vscode from 'vscode';
@@ -27,6 +28,9 @@ export function activate(context: ExtensionContext) {
       return;
     }
 
+    const editor_config = workspace.getConfiguration('editor');
+    const tab_size = editor_config.get('tabSize', JSON_SPACE);
+
     const raw = editor.document.getText();
     let json = null;
 
@@ -40,7 +44,7 @@ export function activate(context: ExtensionContext) {
       return;
     }
 
-    let pretty = JSON.stringify(json, null, JSON_SPACE);
+    let pretty = JSON.stringify(json, null, tab_size);
 
     editor.edit(builder=> {
       const start = new Position(0, 0);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,3 @@
-import * as stripComments from 'strip-json-comments';
-
 import {
   ExtensionContext,
   Position,
@@ -11,6 +9,7 @@ import {
 
 import * as vscode from 'vscode';
 
+const stripComments = require('strip-json-comments');
 const jsonlint = require('jsonlint');
 
 const LINE_SEPERATOR = /\n|\r\n/;


### PR DESCRIPTION
Some other options I considered:

- Use the tab size of the file that is being edited. It wasn't obvious how to get that information using the API. 
- Add a new configuration for this extension. I could see it being annoying to have to configure a second tab size. I could also see there being users who want to have one tab size for their code, and another tab size for their JSON.

Using `editor.tabSize` seems like a reasonable default.

Thank you for considering my pull request 😄 